### PR TITLE
essential container

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It handles reaping zombie processes, propagates `SIGTERM` and `SIGINT` signals, 
 title = "nginx"
 exec = "/usr/sbin/nginx"
 args = ["-D"]
+essential = true
 
 [[services]]
 title = "sshd"

--- a/test/whaleinit.toml
+++ b/test/whaleinit.toml
@@ -10,3 +10,4 @@ exec = "/usr/sbin/nginx"
 [[services]]
 title = "test process"
 exec = "/usr/local/bin/test_parent.sh"
+essential = true


### PR DESCRIPTION
`essential`とマークされたプロセスが落ちるとすべてのプロセスが落ちるようにした